### PR TITLE
 🚑 hotfix: add onClick props in button component

### DIFF
--- a/src/components/common/Button/AuthButton/AuthButton.tsx
+++ b/src/components/common/Button/AuthButton/AuthButton.tsx
@@ -2,10 +2,17 @@ import * as S from '@/components/common/Button/AuthButton/authButton.style';
 
 interface ButtonProps {
   children: string;
+  onClick?: () => void;
 }
 
-const AuthButton: React.FC<ButtonProps> = ({ children }) => {
-  return <S.StyledButton>{children}</S.StyledButton>;
+const AuthButton: React.FC<ButtonProps> = ({ children, onClick }) => {
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    }
+  };
+
+  return <S.StyledButton onClick={handleClick}>{children}</S.StyledButton>;
 };
 
 export default AuthButton;

--- a/src/components/common/Button/CommonButton/CommonButton.tsx
+++ b/src/components/common/Button/CommonButton/CommonButton.tsx
@@ -4,17 +4,28 @@ interface ButtonProps {
   type: 'primary' | 'secondary';
   wide?: boolean;
   isActive?: boolean;
+  onClick?: () => void;
   children: string;
 }
 
 const CommonButton: React.FC<ButtonProps> = ({
   type,
   wide,
-  isActive,
+  isActive = true,
+  onClick,
   children,
 }) => {
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    }
+  };
   return (
-    <S.StyledButton type={type} wide={wide} isActive={isActive}>
+    <S.StyledButton
+      type={type}
+      wide={wide}
+      isActive={isActive}
+      onClick={handleClick}>
       {children}
     </S.StyledButton>
   );

--- a/src/components/common/Button/CommonButton/commonButton.style.ts
+++ b/src/components/common/Button/CommonButton/commonButton.style.ts
@@ -9,20 +9,6 @@ interface ButtonProps {
   children: string;
 }
 
-const commonStyles = css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  width: 173px;
-  padding: 19px 52px;
-
-  font-size: 18px;
-  font-weight: 500;
-
-  cursor: pointer;
-`;
-
 const basicStyles = css`
   width: 173px;
   padding: 19px 52px;
@@ -34,38 +20,46 @@ const wideStyles = css`
 `;
 
 const primaryStyles = css`
-  ${basicStyles}
   background-color: #e4d5c2;
   color: #000;
 `;
 
 const secondaryStyles = css`
-  ${basicStyles}
   border: 1px solid #000;
 `;
+
+const typeMap = {
+  primary: primaryStyles,
+  secondary: secondaryStyles,
+};
 
 const primaryInactiveStyles = css`
   color: #939393;
   background: #eee;
-  cursor: not-allowed;
 `;
 
 const secondaryInactiveStyles = css`
   border: 1px solid #d3d3d3;
   color: #b4b4b4;
   background: #fff;
+`;
+
+const inactiveStyles = ({ type }: ButtonProps) => css`
   cursor: not-allowed;
+
+  ${type === 'primary' ? primaryInactiveStyles : secondaryInactiveStyles}
 `;
 
 export const StyledButton = styled.button<ButtonProps>`
-  ${commonStyles}
-  ${({ type, isActive }) =>
-    type === 'primary'
-      ? isActive
-        ? primaryStyles
-        : primaryInactiveStyles
-      : isActive
-      ? secondaryStyles
-      : secondaryInactiveStyles}
-  ${({ wide }) => wide && wideStyles}
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 18px;
+  font-weight: 500;
+
+  cursor: pointer;
+
+  ${({ type }) => typeMap[type]}
+  ${({ wide }) => (wide ? wideStyles : basicStyles)}
+  ${({ isActive }) => !isActive && inactiveStyles}
 `;

--- a/src/components/common/Button/ControlButton/ControlButton.tsx
+++ b/src/components/common/Button/ControlButton/ControlButton.tsx
@@ -1,13 +1,39 @@
 import * as S from '@/components/common/Button/ControlButton/controlButton.style';
 
 interface ButtonProps {
-  type: 'edit' | 'delete';
+  type: 'edit' | 'delete' | 'editComplete' | 'cancel';
+  onClick?: () => void;
 }
 
-const ControlButton: React.FC<ButtonProps> = ({ type }) => {
+const ControlButton: React.FC<ButtonProps> = ({ type, onClick }) => {
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    }
+  };
+
+  let buttonText = '';
+
+  switch (type) {
+    case 'edit':
+      buttonText = '수정';
+      break;
+    case 'delete':
+      buttonText = '삭제';
+      break;
+    case 'editComplete':
+      buttonText = '수정완료';
+      break;
+    case 'cancel':
+      buttonText = '취소';
+      break;
+    default:
+      break;
+  }
+
   return (
-    <S.StyledButton type={type}>
-      {type === 'edit' ? '수정' : '삭제'}
+    <S.StyledButton type={type} onClick={handleClick}>
+      {buttonText}
     </S.StyledButton>
   );
 };

--- a/src/components/common/Button/ControlButton/controlButton.style.ts
+++ b/src/components/common/Button/ControlButton/controlButton.style.ts
@@ -3,30 +3,41 @@
 import styled, { css } from 'styled-components';
 
 interface ButtonProps {
-  type: 'edit' | 'delete';
+  type: 'edit' | 'delete' | 'editComplete' | 'cancel';
   children: string;
 }
 
-const commonStyles = css`
+const editStyles = css`
+  color: #5d8554;
+`;
+
+const deleteStyles = css`
+  color: #ee5454;
+`;
+
+const editCompleteStyles = css`
+  color: #5d8554;
+`;
+
+const cancelStyles = css`
+  color: #6f6f6f;
+`;
+
+const typeMap = {
+  edit: editStyles,
+  delete: deleteStyles,
+  editComplete: editCompleteStyles,
+  cancel: cancelStyles,
+};
+
+export const StyledButton = styled.button<ButtonProps>`
   font-family: Inter;
   font-size: 15px;
   font-style: normal;
   font-weight: 400;
   line-height: normal;
   letter-spacing: -0.28px;
-
   cursor: pointer;
-`;
 
-const editStyles = css`
-  color: #6f6f6f;
-`;
-
-const deleteStyles = css`
-  color: #de3636;
-`;
-
-export const StyledButton = styled.button<ButtonProps>`
-  ${commonStyles}
-  ${({ type }) => (type === 'edit' ? editStyles : deleteStyles)}
+  ${({ type }) => typeMap[type]}
 `;

--- a/src/components/common/Button/SelectButton/SelectButton.tsx
+++ b/src/components/common/Button/SelectButton/SelectButton.tsx
@@ -3,11 +3,26 @@ import * as S from '@/components/common/Button/SelectButton/selectButton.style';
 
 interface ButtonProps {
   isSelected?: boolean;
+  onClick?: () => void;
   children: string;
 }
 
-const SelectedButton: React.FC<ButtonProps> = ({ isSelected, children }) => {
-  return <S.StyledButton isSelected={isSelected}>{children}</S.StyledButton>;
+const SelectedButton: React.FC<ButtonProps> = ({
+  isSelected,
+  onClick,
+  children,
+}) => {
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+    }
+  };
+
+  return (
+    <S.StyledButton isSelected={isSelected} onClick={handleClick}>
+      {children}
+    </S.StyledButton>
+  );
 };
 
 export default SelectedButton;

--- a/src/components/common/Button/SelectButton/selectButton.style.ts
+++ b/src/components/common/Button/SelectButton/selectButton.style.ts
@@ -7,7 +7,18 @@ interface ButtonProps {
   children: string;
 }
 
-const commonStyles = css`
+const nonSelectedStyles = css`
+  border: 1px solid #e0e0e0;
+  color: #616161;
+  background: #f7f9fb;
+`;
+
+const selectedStyles = css`
+  color: #fff;
+  background: #5d8554;
+`;
+
+export const StyledButton = styled.button<ButtonProps>`
   display: flex;
   justify-content: center;
   align-items: center;
@@ -21,20 +32,5 @@ const commonStyles = css`
   letter-spacing: -0.5px;
 
   cursor: pointer;
-`;
-
-const nonSelectedStyles = css`
-  border: 1px solid #e0e0e0;
-  color: #616161;
-  background: #f7f9fb;
-`;
-
-const selectedStyles = css`
-  color: #fff;
-  background: #5d8554;
-`;
-
-export const StyledButton = styled.button<ButtonProps>`
-  ${commonStyles}
   ${({ isSelected }) => (isSelected ? selectedStyles : nonSelectedStyles)}
 `;


### PR DESCRIPTION
# 주요 변경 사항
- 버튼 컴포넌트 내 onClick props 추가 
- controlButton 타입 추가
- 불필요한 style 코드 삭제 및 수정

# 특이사항
- 현재 버튼 컴포넌트를 사용중인 페이지가 퍼블리싱 단계로, onclick을 props로 안받고 있기 경우가 많아 일단 optional chaning으로 걸어놨습니다.