### PR TITLE
✨ feat: list page publishing

### DIFF
--- a/public/mock/childListItem.json
+++ b/public/mock/childListItem.json
@@ -1,0 +1,24 @@
+{
+  "data": [
+    {
+      "postId": 1,
+      "title": "child01",
+      "date": "2020.10.10"
+    },
+    {
+      "postId": 2,
+      "title": "child02",
+      "date": "2020.10.10"
+    },
+    {
+      "postId": 3,
+      "title": "child03",
+      "date": "2020.10.10"
+    },
+    {
+      "postId": 4,
+      "title": "child04",
+      "date": "2020.10.10"
+    }
+  ]
+}

--- a/public/mock/listDetail.json
+++ b/public/mock/listDetail.json
@@ -1,0 +1,8 @@
+{
+  "data": {
+    "postId": 1,
+    "title": "pet01",
+    "content": "Lorem ipsum dolor sit amet consectetur. Ultrices tristique a elit tempordiam amet. Suscipit arcu bibendum malesuada tincidunt erat nulla turpisfermentum velit. Aliquam quam enim morbi orci turpis amet adipiscingjusto. Id turpis nibh arcu phasellus imperdiet.",
+    "date": "2020.10.10"
+  }
+}

--- a/public/mock/petListItem.json
+++ b/public/mock/petListItem.json
@@ -1,0 +1,24 @@
+{
+  "data": [
+    {
+      "postId": 1,
+      "title": "pet01",
+      "date": "2020.10.10"
+    },
+    {
+      "postId": 2,
+      "title": "pet02",
+      "date": "2020.10.10"
+    },
+    {
+      "postId": 3,
+      "title": "pet03",
+      "date": "2020.10.10"
+    },
+    {
+      "postId": 4,
+      "title": "pet04",
+      "date": "2020.10.10"
+    }
+  ]
+}

--- a/src/app/list/[slug]/[id]/listDetail.style.ts
+++ b/src/app/list/[slug]/[id]/listDetail.style.ts
@@ -1,0 +1,41 @@
+'use client';
+import styled from 'styled-components';
+
+export const InquiryDetailContainer = styled.div`
+  width: 100%;
+  margin: auto;
+  margin-top: 120px;
+  border-top: 1px solid #d4d4d4;
+`;
+
+export const HeaderContainer = styled.div`
+  margin: 47px 0;
+`;
+
+export const InquiryHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 16px;
+`;
+export const InquiryTitle = styled.div`
+  font-size: 32px;
+  font-weight: 500;
+`;
+export const InquiryInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 26px;
+`;
+export const Date = styled.div`
+  color: #6f6f6f;
+  font-size: 15px;
+  font-weight: 400;
+`;
+
+export const ImageContainer = styled.div``;
+
+export const InquiryBody = styled.div`
+  font-size: 16px;
+  line-height: 32px;
+  margin-bottom: 67px;
+`;

--- a/src/app/list/[slug]/[id]/page.tsx
+++ b/src/app/list/[slug]/[id]/page.tsx
@@ -1,0 +1,51 @@
+'use client';
+import React from 'react';
+import { useEffect, useState } from 'react';
+import { ListItem } from '@/types/apis/listItem';
+import PageTitle from '@/components/PageTitle/PageTitle';
+import * as S from './listDetail.style';
+
+type Props = {
+  params: {
+    slug: string;
+    id: string;
+  };
+};
+
+export default function ListDetail({ params }: Props) {
+  const [listItem, setListItem] = useState<ListItem>({
+    postId: 0,
+    title: '',
+    content: '',
+    date: '',
+    //image data 필요.
+  });
+
+  useEffect(() => {
+    //TODO api 분리 후 id에 따라 다이나믹 통신하기!
+    // 백엔드랑 통신시 api 주소 및 양식 변경 예정
+    fetch(`/mock/listDetail.json`)
+      .then((res) => res.json())
+      .then((result: { data: ListItem }) => setListItem(result.data));
+  }, []);
+
+  return (
+    <>
+      <PageTitle>{params.slug.toUpperCase()}</PageTitle>
+      <S.InquiryDetailContainer>
+        <S.HeaderContainer>
+          <S.InquiryHeader>
+            <S.InquiryTitle>{listItem.title}</S.InquiryTitle>
+            <S.InquiryInfo>
+              <S.Date>{listItem.date}</S.Date>
+            </S.InquiryInfo>
+          </S.InquiryHeader>
+        </S.HeaderContainer>
+
+        <S.ImageContainer></S.ImageContainer>
+
+        <S.InquiryBody>{listItem.content}</S.InquiryBody>
+      </S.InquiryDetailContainer>
+    </>
+  );
+}

--- a/src/app/list/[slug]/layout.tsx
+++ b/src/app/list/[slug]/layout.tsx
@@ -1,0 +1,13 @@
+'use client';
+import type { Metadata } from 'next';
+import Mainpage from '@/components/MainPage/MainPage';
+
+interface Props {
+  children: React.ReactNode;
+}
+
+const Layout = ({ children }: Props) => {
+  return <Mainpage>{children}</Mainpage>;
+};
+
+export default Layout;

--- a/src/app/list/[slug]/list.style.ts
+++ b/src/app/list/[slug]/list.style.ts
@@ -1,0 +1,60 @@
+'use client';
+import styled from 'styled-components';
+
+export const ListSubtitle = styled.div`
+  display: flex;
+  justify-content: center;
+  font-size: 18px;
+  margin-bottom: 90px;
+`;
+
+export const Section = styled.section`
+  width: 100%;
+  max-height: 864px;
+  margin: 0 auto;
+  margin-top: 64px;
+
+  border-top: solid 1px #4b4b4b;
+`;
+
+export const ListCategory = styled.div`
+  width: 100%;
+  padding: 20px 70px 20px 50px;
+
+  display: flex;
+  justify-content: space-between;
+`;
+
+export const ListCategoryItem = styled.div`
+  color: #000;
+  text-align: center;
+  font-family: Inter;
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 100%;
+  letter-spacing: -0.28px;
+`;
+
+export const ListItem = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  gap: 90px;
+
+  padding: 30px 50px 30px 54px;
+  border-top: solid 1px #e6e6e6;
+
+  font-size: 17px;
+  font-weight: 300;
+`;
+
+export const ListItemId = styled.div`
+  width: 12px;
+`;
+
+export const ListItemTitle = styled.div`
+  width: 800px;
+`;
+
+export const ListItemDate = styled.div``;

--- a/src/app/list/[slug]/page.tsx
+++ b/src/app/list/[slug]/page.tsx
@@ -1,0 +1,53 @@
+'use client';
+import { useEffect, useState } from 'react';
+import PageTitle from '@/components/PageTitle/PageTitle';
+import Mainpage from '@/components/MainPage/MainPage';
+import SearchBar from '@/components/common/SearchBar/SearchBar';
+import PageButton from '@/components/ListPage/PageButton/PageButton';
+import { ListItem } from '@/types/apis/listItem';
+import * as S from './list.style';
+
+type Props = {
+  params: {
+    slug: string;
+  };
+};
+
+export default function ListPage({ params }: Props) {
+  const [listItems, setListItems] = useState<ListItem[]>([]);
+
+  useEffect(() => {
+    //TODO api 분리 후 slug에 따라 다이나믹 통신하기!
+    // 백엔드랑 통신시 api 주소 및 양식 변경 예정
+    fetch(`/mock/${params.slug}ListItem.json`)
+      .then((res) => res.json())
+      .then((result: { data: ListItem[] }) => setListItems(result.data));
+  }, []);
+
+  const renderingListItems = () => {
+    return listItems.map((item, index) => (
+      <S.ListItem key={index}>
+        <S.ListItemId>{item.postId}</S.ListItemId>
+        <S.ListItemTitle>{item.title}</S.ListItemTitle>
+        <S.ListItemDate>{item.date}</S.ListItemDate>
+      </S.ListItem>
+    ));
+  };
+
+  return (
+    <>
+      <PageTitle>{params.slug.toUpperCase()}</PageTitle>
+      <S.ListSubtitle>새로운 소식 및 공지 사항을 알려드립니다.</S.ListSubtitle>
+      <SearchBar></SearchBar>
+      <S.Section>
+        <S.ListCategory>
+          <S.ListCategoryItem>NO</S.ListCategoryItem>
+          <S.ListCategoryItem>제목</S.ListCategoryItem>
+          <S.ListCategoryItem>등록일</S.ListCategoryItem>
+        </S.ListCategory>
+        {renderingListItems()}
+      </S.Section>
+      <PageButton></PageButton>
+    </>
+  );
+}

--- a/src/components/ListPage/PageButton/PageButton.tsx
+++ b/src/components/ListPage/PageButton/PageButton.tsx
@@ -1,0 +1,12 @@
+import { ListPageButton, PaginationContainer } from './pageButton.style';
+
+function PageButton() {
+  //TODO 페이지네이션 조율 후 변경 예정
+  return (
+    <PaginationContainer>
+      <ListPageButton>1</ListPageButton>
+    </PaginationContainer>
+  );
+}
+
+export default PageButton;

--- a/src/components/ListPage/PageButton/pageButton.style.ts
+++ b/src/components/ListPage/PageButton/pageButton.style.ts
@@ -1,0 +1,25 @@
+import styled from 'styled-components';
+
+export const PaginationContainer = styled.div`
+  display: flex;
+  width: auto;
+  height: 32px;
+  margin: 0 auto;
+  margin-top: 48px;
+  justify-content: center;
+  align-items: center;
+`;
+
+export const ListPageButton = styled.div`
+  display: flex;
+  width: 32px;
+  height: 32px;
+  padding: 8px 0px;
+  justify-content: center;
+  align-items: center;
+
+  border: 1px solid #e4d5c2;
+  background: #e4d5c2;
+
+  cursor: pointer;
+`;

--- a/src/types/apis/listItem.ts
+++ b/src/types/apis/listItem.ts
@@ -1,0 +1,7 @@
+export interface ListItem {
+  postId: number;
+  title: string;
+  content: string;
+  date: string;
+  //image 관련 키 필요
+}


### PR DESCRIPTION
# 주요 구현 사항
- 게시글 리스트 페이지 UI
- 게시글 상세 페이지 UI
- slug, id 에 따라 동적 랜더링

# 추후 구현 사항
- 이미지 영역 (최대 크기 및 사이즈가 정해지면 구현 예정)
- admin 유저일 시 수정 및 삭제 기능 추가
- 페이지네이션 (현재 버튼 UI만 존재, 추후 방법 논의 후 수정 예정)

# 피그마 UI
1. 게시글 리스트 페이지
![리스트](https://github.com/ParkGeonRyul/Eden-Front/assets/77326740/17068102-e2a9-4d21-be94-e8177dca6a47)

2. 게시글 상세 페이지
![유형별 게시글 상세- 일반유저](https://github.com/ParkGeonRyul/Eden-Front/assets/77326740/2d82fdbc-2ec5-4b06-9018-b7f6425d12f0)
