### PR TITLE
💄 style    : Adjust prettier config to srot imports

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -4,5 +4,22 @@
   "semi": true,
   "singleQuote": true,
   "trailingComma": "all",
-  "tabWidth": 2
+  "plugins": ["@trivago/prettier-plugin-sort-imports"],
+  "tabWidth": 2,
+  "importOrder": [
+    "^react",
+    "^next",
+    "<THIRD_PARTY_MODULES>",
+
+    "^~/api/(.*)$",
+    "^~/hooks/(.*)$",
+    "^~/components/(.*)$",
+    "^~/utils/(.*)$",
+    "^~/interfaces/(.*)$",
+    "^~/types/(.*)$",
+    "^@styles/(.*)$",
+    "^[./]"
+  ],
+  "importOrderSeparation": false,
+  "importOrderSortSpecifiers": true
 }

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 <!-- - recoil -> 미정 -->
 - tanstack@react-query
 
-** 추가할 내용
+\*\* 추가할 내용
+
 - 폴더구조 및 설명
 - code convention 등 각종 컨벤션 설명

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
       },
       "devDependencies": {
         "@svgr/webpack": "^8.1.0",
+        "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -4008,6 +4009,115 @@
         "react-dom": "^18.0.0"
       }
     },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.3.0.tgz",
+      "integrity": "sha512-r3n0onD3BTOVUNPhR4lhVK4/pABGpbA7bW3eumZnYdKaHkf1qEC+Mag6DPbGNuuh0eG8AaYj+YqmVHSiGslaTQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "^7.20.5",
+        "@babel/traverse": "7.23.2",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "^4.17.21"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x - 3.x"
+      },
+      "peerDependenciesMeta": {
+        "@vue/compiler-sfc": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
+        "@babel/helper-hoist-variables": "^7.22.5",
+        "@babel/helper-split-export-declaration": "^7.22.6",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/@babel/generator": {
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.23.6",
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "@jridgewell/trace-mapping": "^0.3.17",
+        "jsesc": "^2.5.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse/node_modules/@babel/types": {
+      "version": "7.24.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.24.0.tgz",
+      "integrity": "sha512-+j7a5c253RfKh8iABBhywc8NSfP5LURe7Uh4qpsh6jc+aLJguvmIUBdjSdEMQv2bENrCR5MfRdjGo7vzS/ob7w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -6551,6 +6661,12 @@
         "set-function-name": "^2.0.1"
       }
     },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7216,6 +7332,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7700,6 +7832,15 @@
       "dependencies": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "@svgr/webpack": "^8.1.0",
+    "@trivago/prettier-plugin-sort-imports": "^4.3.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/app/ReactQueryProvider.tsx
+++ b/src/app/ReactQueryProvider.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import { PropsWithChildren, useState } from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { PropsWithChildren, useState } from 'react';
 
 export default function ReactQueryProvider({ children }: PropsWithChildren) {
   const [queryClient] = useState(() => new QueryClient());

--- a/src/app/admin/[slug]/[id]/detailPage.style.ts
+++ b/src/app/admin/[slug]/[id]/detailPage.style.ts
@@ -1,2 +1,3 @@
 'use client';
+
 import styled, { css } from 'styled-components';

--- a/src/app/admin/[slug]/[id]/page.tsx
+++ b/src/app/admin/[slug]/[id]/page.tsx
@@ -1,11 +1,12 @@
 'use client';
+
 import React, { useState } from 'react';
-import * as S from './detailPage.style';
+import AnswerContent from '@/components/InquiryDetail/AnswerContent/AnswerContent';
+import InquiryContent from '@/components/InquiryDetail/InquiryContent/InquiryContent';
+import ListContent from '@/components/InquiryDetail/ListContent/ListContent';
 import Mainpage from '@/components/common/MainPage/MainPage';
 import PageTitle from '@/components/common/PageTitle/PageTitle';
-import InquiryContent from '@/components/InquiryDetail/InquiryContent/InquiryContent';
-import AnswerContent from '@/components/InquiryDetail/AnswerContent/AnswerContent';
-import ListContent from '@/components/InquiryDetail/ListContent/ListContent';
+import * as S from './detailPage.style';
 
 const ListDetailPage = () => {
   return (

--- a/src/app/admin/[slug]/page.tsx
+++ b/src/app/admin/[slug]/page.tsx
@@ -1,15 +1,16 @@
 'use client';
+
 import { useEffect, useState } from 'react';
-import CategoryList from '@/components/CategoryList/CategoryList';
-import Mainpage from '@/components/common/MainPage/MainPage';
-import PageTitle from '@/components/common/PageTitle/PageTitle';
-import AnswerStatusLabel from '@/components/common/Label/AnswerStatusLabel/AnswerStatusLabel';
-import { adminListItem, adminListData } from '@/types/apis/adminListItem';
-import PaginationButtons from '@/components/common/Pagination/Pagination';
-import axios from 'axios';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import CategoryList from '@/components/CategoryList/CategoryList';
 import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
+import AnswerStatusLabel from '@/components/common/Label/AnswerStatusLabel/AnswerStatusLabel';
+import Mainpage from '@/components/common/MainPage/MainPage';
+import PageTitle from '@/components/common/PageTitle/PageTitle';
+import PaginationButtons from '@/components/common/Pagination/Pagination';
+import { adminListData, adminListItem } from '@/types/apis/adminListItem';
+import axios from 'axios';
 import * as S from './list.style';
 
 interface AdminListPageProps {

--- a/src/app/admin/admin.style.ts
+++ b/src/app/admin/admin.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const Category = styled.div`

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,10 +1,11 @@
 'use client';
+
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import * as S from './admin.style';
+import Label from '@/components/common/Label/AnswerStatusLabel/AnswerStatusLabel';
 import Mainpage from '@/components/common/MainPage/MainPage';
 import PageTitle from '@/components/common/PageTitle/PageTitle';
-import Label from '@/components/common/Label/AnswerStatusLabel/AnswerStatusLabel';
-import Link from 'next/link';
+import * as S from './admin.style';
 
 interface categoryList {
   category: string;

--- a/src/app/history/history.style.ts
+++ b/src/app/history/history.style.ts
@@ -1,6 +1,7 @@
 'use client';
-import styled from 'styled-components';
+
 import Image from 'next/image';
+import styled from 'styled-components';
 
 export const SubTitle = styled.div`
   text-align: center;

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -1,7 +1,8 @@
 'use client';
-import * as S from './history.style';
+
 import Mainpage from '@/components/common/MainPage/MainPage';
 import PageTitle from '@/components/common/PageTitle/PageTitle';
+import * as S from './history.style';
 
 interface infoItems {
   infoItems: string;

--- a/src/app/home.style.ts
+++ b/src/app/home.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const MainContainer = styled.div`

--- a/src/app/inquiry/inquiry.style.ts
+++ b/src/app/inquiry/inquiry.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const InquirySubtitle = styled.div`

--- a/src/app/inquiry/page.tsx
+++ b/src/app/inquiry/page.tsx
@@ -1,19 +1,19 @@
 'use client';
+
 import { useState } from 'react';
-import PageTitle from '@/components/common/PageTitle/PageTitle';
-import CheckBox from '@/components/common/CheckBox/CheckBox';
-import Mainpage from '@/components/common/MainPage/MainPage';
-import DropDown from '@/components/common/DropDown/DropDown';
-import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
 import InquiryModal from '@/components/Modal/InquiryModal/InquiryModal';
 import SearchModal from '@/components/Modal/SearchModal/SearchModal';
+import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
+import CheckBox from '@/components/common/CheckBox/CheckBox';
+import DropDown from '@/components/common/DropDown/DropDown';
+import Mainpage from '@/components/common/MainPage/MainPage';
+import PageTitle from '@/components/common/PageTitle/PageTitle';
 import useModal from '@/hooks/useModal/usemodal';
-import * as S from './inquiry.style';
-
 import {
-  validateInquiryData,
   isContentLengthValid,
+  validateInquiryData,
 } from '@/utils/inquiry/validateInquiryData';
+import * as S from './inquiry.style';
 
 export default function Inquiry() {
   const { Modal, open, close } = useModal();

--- a/src/app/inquiry/post/page.tsx
+++ b/src/app/inquiry/post/page.tsx
@@ -1,10 +1,11 @@
 'use client';
+
 import React, { useState } from 'react';
-import * as S from './post.style';
-import Mainpage from '@/components/common/MainPage/MainPage';
-import PageTitle from '@/components/common/PageTitle/PageTitle';
 import ControlButton from '@/components/common/Button/ControlButton/ControlButton';
 import Label from '@/components/common/Label/AnswerStatusLabel/AnswerStatusLabel';
+import Mainpage from '@/components/common/MainPage/MainPage';
+import PageTitle from '@/components/common/PageTitle/PageTitle';
+import * as S from './post.style';
 
 const Post = () => {
   const [answerText, setAnswerText] = useState('');

--- a/src/app/inquiry/post/post.style.ts
+++ b/src/app/inquiry/post/post.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const InquiryDetailContainer = styled.div`

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
+import Header from '@/components/common/Header/Header';
 import StyledComponentsRegistry from '@/styles/registry';
 import ReactQueryProvider from './ReactQueryProvider';
-import Header from '@/components/common/Header/Header';
 
 interface Props {
   children: React.ReactNode;

--- a/src/app/list/[slug]/list.style.ts
+++ b/src/app/list/[slug]/list.style.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import Link from 'next/link';
+import styled from 'styled-components';
 
 export const ListSubtitle = styled.div`
   display: flex;

--- a/src/app/list/[slug]/page.tsx
+++ b/src/app/list/[slug]/page.tsx
@@ -1,11 +1,12 @@
 'use client';
+
 import { useEffect, useState } from 'react';
-import axios from 'axios';
-import PageTitle from '@/components/common/PageTitle/PageTitle';
-import SearchBar from '@/components/common/SearchBar/SearchBar';
 import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
+import PageTitle from '@/components/common/PageTitle/PageTitle';
 import PaginationButtons from '@/components/common/Pagination/Pagination';
-import { ListItem, ListData } from '@/types/apis/listItem';
+import SearchBar from '@/components/common/SearchBar/SearchBar';
+import { ListData, ListItem } from '@/types/apis/listItem';
+import axios from 'axios';
 import * as S from './list.style';
 
 const LIMIT_PER_PAGE = 5;

--- a/src/app/mypage/edit/edit.style.ts
+++ b/src/app/mypage/edit/edit.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const Mypage = styled.div`

--- a/src/app/mypage/edit/page.tsx
+++ b/src/app/mypage/edit/page.tsx
@@ -1,13 +1,14 @@
 'use client';
-import { useState, useEffect } from 'react';
+
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
-import ProfileSection from '@/components/Mypage/Info/ProfileInfoSection/ProfileInfoSection';
-import BasicInfoSection from '@/components/Mypage/Info/BasicInfoSection/BasicInfoSection';
-import EmailAuthModal from '@/components/Modal/EmailAuthModal/EmailAuthModal';
 import AddressModal from '@/components/Modal/AddressModal/AddressModal';
-import useModal from '@/hooks/useModal/usemodal';
+import EmailAuthModal from '@/components/Modal/EmailAuthModal/EmailAuthModal';
+import BasicInfoSection from '@/components/Mypage/Info/BasicInfoSection/BasicInfoSection';
+import ProfileSection from '@/components/Mypage/Info/ProfileInfoSection/ProfileInfoSection';
 import { addActiveToBasicInfoData } from '@/components/Mypage/Info/basicInfoConstants';
+import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
+import useModal from '@/hooks/useModal/usemodal';
 import { UserInfo } from '@/types/apis/userInfo';
 import * as S from './edit.style';
 

--- a/src/app/mypage/info.style.ts
+++ b/src/app/mypage/info.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const Mypage = styled.div`

--- a/src/app/mypage/inquiry/inquiry.style.ts
+++ b/src/app/mypage/inquiry/inquiry.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const NotInquiry = styled.div`

--- a/src/app/mypage/inquiry/page.tsx
+++ b/src/app/mypage/inquiry/page.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { useState, useEffect } from 'react';
+
+import { useEffect, useState } from 'react';
 import InquiryDetail from '@/components/Mypage/Inquiry/InquiryDetail/InquiryDetail';
 import InquiryListItem from '@/components/Mypage/Inquiry/InquiryList/InquiryListItem';
 import { InquiryPostData } from '@/types/apis/userInquiry';

--- a/src/app/mypage/layout.tsx
+++ b/src/app/mypage/layout.tsx
@@ -1,5 +1,5 @@
-import SideNav from '@/components/Mypage/SideNav/Sidenav';
 import * as S from '@/app/mypage/info.style';
+import SideNav from '@/components/Mypage/SideNav/Sidenav';
 
 export default function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/src/app/mypage/page.tsx
+++ b/src/app/mypage/page.tsx
@@ -1,10 +1,11 @@
 'use client';
-import { useState, useEffect } from 'react';
+
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
-import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
-import ProfileSection from '@/components/Mypage/Info/ProfileInfoSection/ProfileInfoSection';
 import BasicInfoSection from '@/components/Mypage/Info/BasicInfoSection/BasicInfoSection';
+import ProfileSection from '@/components/Mypage/Info/ProfileInfoSection/ProfileInfoSection';
 import { createBasicInfoData } from '@/components/Mypage/Info/basicInfoConstants';
+import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
 import { UserInfo } from '@/types/apis/userInfo';
 import * as S from './info.style';
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,11 @@
 'use client';
-import { useState, useEffect } from 'react';
-import axios from 'axios';
-import * as S from './home.style';
-import { MainTitle } from '@/types/apis/mainTitle';
+
+import { useEffect, useState } from 'react';
 import { Typewriter } from 'react-simple-typewriter';
 import Mainpage from '@/components/common/MainPage/MainPage';
+import { MainTitle } from '@/types/apis/mainTitle';
+import axios from 'axios';
+import * as S from './home.style';
 
 export default function Home() {
   const [selectedLanguage, setSelectedLanguage] = useState<{

--- a/src/app/reservation/page.tsx
+++ b/src/app/reservation/page.tsx
@@ -1,8 +1,9 @@
 'use client';
-import PageTitle from '@/components/common/PageTitle/PageTitle';
-import Mainpage from '@/components/common/MainPage/MainPage';
-import CheckBox from '@/components/common/CheckBox/CheckBox';
+
 import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
+import CheckBox from '@/components/common/CheckBox/CheckBox';
+import Mainpage from '@/components/common/MainPage/MainPage';
+import PageTitle from '@/components/common/PageTitle/PageTitle';
 import * as S from './reservation.style';
 
 const Reservation = () => {

--- a/src/app/reservation/reservation.style.ts
+++ b/src/app/reservation/reservation.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const SubTitle = styled.div`

--- a/src/components/FormPage/Container/FormPageContainer.tsx
+++ b/src/components/FormPage/Container/FormPageContainer.tsx
@@ -1,16 +1,17 @@
 'use client';
+
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import FormPage from '@/components/FormPage/UI/FormPage';
-import { ListItemDetail, UploadFileData } from '@/types/apis/listItem';
-import { ListProps } from '@/interfaces/listPage';
-import { FormType } from '@/types/components/formTypes';
+import getCategoryTypeFromSlug from '@/components/FormPage/utils/getCategoryTypeFromSlug';
 import {
   isContentLengthValid,
   validateInputData,
 } from '@/components/FormPage/utils/postValid';
-import getCategoryTypeFromSlug from '@/components/FormPage/utils/getCategoryTypeFromSlug';
 import updateFormData from '@/components/FormPage/utils/updatdFormData';
+import { ListProps } from '@/interfaces/listPage';
+import { ListItemDetail, UploadFileData } from '@/types/apis/listItem';
+import { FormType } from '@/types/components/formTypes';
 
 interface FormPageContainerProps extends ListProps {
   type: FormType;

--- a/src/components/FormPage/UI/FormPage.tsx
+++ b/src/components/FormPage/UI/FormPage.tsx
@@ -1,9 +1,9 @@
-import PageTitle from '@/components/common/PageTitle/PageTitle';
 import DropDown from '@/components/common/DropDown/DropDown';
-import FormButton from './FormButton/FormButton';
-import FilesInputButton from './FilesInput/FilesInput';
+import PageTitle from '@/components/common/PageTitle/PageTitle';
 import { FormInputData } from '@/interfaces/listPage';
 import { FormType } from '@/types/components/formTypes';
+import FilesInputButton from './FilesInput/FilesInput';
+import FormButton from './FormButton/FormButton';
 import * as S from './formPage.style';
 
 interface FormPageProps {

--- a/src/components/InquiryDetail/AnswerContent/AnswerContent.tsx
+++ b/src/components/InquiryDetail/AnswerContent/AnswerContent.tsx
@@ -1,7 +1,8 @@
 'use client';
-import * as S from './answerConten.style';
+
 import React, { useState } from 'react';
 import ControlButton from '@/components/common/Button/ControlButton/ControlButton';
+import * as S from './answerConten.style';
 
 const AnswerContent = () => {
   const [answerText, setAnswerText] = useState('');

--- a/src/components/InquiryDetail/AnswerContent/answerConten.style.ts
+++ b/src/components/InquiryDetail/AnswerContent/answerConten.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled, { css } from 'styled-components';
 
 export const AnswerContainer = styled.div<{ answerWrite: boolean }>`

--- a/src/components/InquiryDetail/InquiryContent/InquiryContent.tsx
+++ b/src/components/InquiryDetail/InquiryContent/InquiryContent.tsx
@@ -1,6 +1,7 @@
 'use client';
-import * as S from './inquiryContent.style';
+
 import Label from '@/components/common/Label/AnswerStatusLabel/AnswerStatusLabel';
+import * as S from './inquiryContent.style';
 
 const InquiryContent = () => {
   return (

--- a/src/components/InquiryDetail/InquiryContent/inquiryContent.style.ts
+++ b/src/components/InquiryDetail/InquiryContent/inquiryContent.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const DetailContainer = styled.div`

--- a/src/components/InquiryDetail/ListContent/ListContent.tsx
+++ b/src/components/InquiryDetail/ListContent/ListContent.tsx
@@ -1,6 +1,7 @@
 'use client';
-import * as S from './listContent.style';
+
 import Label from '@/components/common/Label/AnswerStatusLabel/AnswerStatusLabel';
+import * as S from './listContent.style';
 
 const ListContent = () => {
   return (

--- a/src/components/InquiryDetail/ListContent/listContent.style.ts
+++ b/src/components/InquiryDetail/ListContent/listContent.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const ListTable = styled.div`

--- a/src/components/ListDetail/UI/ListDetailPage.tsx
+++ b/src/components/ListDetail/UI/ListDetailPage.tsx
@@ -1,9 +1,10 @@
 'use client';
+
+import Image from 'next/image';
+import * as S from '@/components/ListDetail/UI/listDetailPage.style';
 import ControlButton from '@/components/common/Button/ControlButton/ControlButton';
 import PageTitle from '@/components/common/PageTitle/PageTitle';
 import { ListItemDetail } from '@/types/apis/listItem';
-import * as S from '@/components/ListDetail/UI/listDetailPage.style';
-import Image from 'next/image';
 
 interface ListDetailPageProps {
   listItemDetail: ListItemDetail;

--- a/src/components/ListDetail/UI/listDetailPage.style.ts
+++ b/src/components/ListDetail/UI/listDetailPage.style.ts
@@ -1,7 +1,8 @@
 'use client';
-import styled from 'styled-components';
-import Link from 'next/link';
+
 import Image from 'next/image';
+import Link from 'next/link';
+import styled from 'styled-components';
 
 export const ListDetailContainer = styled.div`
   width: 100%;

--- a/src/components/Modal/AddressModal/addressModal.style.ts
+++ b/src/components/Modal/AddressModal/addressModal.style.ts
@@ -1,5 +1,6 @@
 'use client';
-import { styled, css } from 'styled-components';
+
+import { css, styled } from 'styled-components';
 
 export const ModalContainer = styled.div`
   display: flex;

--- a/src/components/Modal/AuthModal/AgreeMent/AgreeMent.tsx
+++ b/src/components/Modal/AuthModal/AgreeMent/AgreeMent.tsx
@@ -1,9 +1,10 @@
 'use client';
+
 import React, { useState } from 'react';
-import * as S from './agreeMent.style';
-import * as I from '@/components/icons';
-import CheckBox from '@/components/common/CheckBox/CheckBox';
 import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
+import CheckBox from '@/components/common/CheckBox/CheckBox';
+import * as I from '@/components/icons';
+import * as S from './agreeMent.style';
 
 interface AgreeMentProps {
   goToSignUp: () => void;

--- a/src/components/Modal/AuthModal/AgreeMent/agreeMent.style.ts
+++ b/src/components/Modal/AuthModal/AgreeMent/agreeMent.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 interface RequiredState {

--- a/src/components/Modal/AuthModal/Auth.tsx
+++ b/src/components/Modal/AuthModal/Auth.tsx
@@ -1,10 +1,11 @@
 'use client';
+
 import React, { useState } from 'react';
-import * as S from './auth.styled';
+import useModal from '@/hooks/useModal/usemodal';
+import AgreeMent from './AgreeMent/AgreeMent';
 import SignIn from './SignIn/SignIn';
 import SignUp from './SignUp/SignUp';
-import AgreeMent from './AgreeMent/AgreeMent';
-import useModal from '@/hooks/useModal/usemodal';
+import * as S from './auth.styled';
 
 const INITIAL_MODAL = 'SignIn';
 

--- a/src/components/Modal/AuthModal/SignIn/SignIn.tsx
+++ b/src/components/Modal/AuthModal/SignIn/SignIn.tsx
@@ -1,8 +1,9 @@
 'use client';
-import * as S from './signIn.style';
-import * as I from '@/components/icons';
+
 import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
 import LinkButton from '@/components/common/Button/LinkButton';
+import * as I from '@/components/icons';
+import * as S from './signIn.style';
 
 interface SignInProps {
   goToAgreeMent: () => void;

--- a/src/components/Modal/AuthModal/SignIn/signIn.style.ts
+++ b/src/components/Modal/AuthModal/SignIn/signIn.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const OpenBtn = styled.button``;

--- a/src/components/Modal/AuthModal/SignUp/SignUp.tsx
+++ b/src/components/Modal/AuthModal/SignUp/SignUp.tsx
@@ -1,9 +1,10 @@
 'use client';
-import CheckBox from '@/components/common/CheckBox/CheckBox';
-import * as S from './signUp.style';
-import * as I from '@/components/icons';
-import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
+
 import AuthButton from '@/components/common/Button/AuthButton/AuthButton';
+import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
+import CheckBox from '@/components/common/CheckBox/CheckBox';
+import * as I from '@/components/icons';
+import * as S from './signUp.style';
 
 interface SignUpProps {
   close: () => void;

--- a/src/components/Modal/AuthModal/SignUp/signUp.style.ts
+++ b/src/components/Modal/AuthModal/SignUp/signUp.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const BackGround = styled.div`

--- a/src/components/Modal/AuthModal/auth.styled.ts
+++ b/src/components/Modal/AuthModal/auth.styled.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const LoginButton = styled.div``;

--- a/src/components/Modal/EmailAuthModal/EmailAuthModal.tsx
+++ b/src/components/Modal/EmailAuthModal/EmailAuthModal.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
 import AuthButton from '@/components/common/Button/AuthButton/AuthButton';
+import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
 import { ModalCloseButton } from '@/components/icons';
 import * as S from './emailAuthModal.style';
 

--- a/src/components/Modal/EmailAuthModal/emailAuthModal.style.ts
+++ b/src/components/Modal/EmailAuthModal/emailAuthModal.style.ts
@@ -1,5 +1,6 @@
 'use client';
-import { styled, css } from 'styled-components';
+
+import { css, styled } from 'styled-components';
 
 export const ModalContainer = styled.div`
   position: relative;

--- a/src/components/Modal/InquiryModal/InquiryModal.tsx
+++ b/src/components/Modal/InquiryModal/InquiryModal.tsx
@@ -1,7 +1,8 @@
 'use client';
+
 import React from 'react';
-import * as IM from './inquiryModal.style';
 import * as I from '@/components/icons';
+import * as IM from './inquiryModal.style';
 
 interface InquiryModalProps {
   close: () => void;

--- a/src/components/Modal/InquiryModal/inquiryModal.style.ts
+++ b/src/components/Modal/InquiryModal/inquiryModal.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const InquiryModal = styled.div`

--- a/src/components/Modal/SearchModal/SearchModal.tsx
+++ b/src/components/Modal/SearchModal/SearchModal.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
-import * as S from './searchModal.style';
-import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
 import { useRouter } from 'next/navigation';
+import CommonButton from '@/components/common/Button/CommonButton/CommonButton';
+import * as S from './searchModal.style';
 
 interface SearchModalProps {
   close: () => void;

--- a/src/components/Modal/SearchModal/searchModal.style.ts
+++ b/src/components/Modal/SearchModal/searchModal.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const SearchModal = styled.div`

--- a/src/components/Mypage/Info/BasicInfoSection/basicInfoSection.style.ts
+++ b/src/components/Mypage/Info/BasicInfoSection/basicInfoSection.style.ts
@@ -1,5 +1,6 @@
 'use client';
-import { styled, css } from 'styled-components';
+
+import { css, styled } from 'styled-components';
 
 interface InfoContentProps {
   active: boolean;

--- a/src/components/Mypage/Info/ProfileInfoSection/profileInfoSection.style.ts
+++ b/src/components/Mypage/Info/ProfileInfoSection/profileInfoSection.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const InfoSection = styled.div`

--- a/src/components/Mypage/Info/basicInfoConstants.ts
+++ b/src/components/Mypage/Info/basicInfoConstants.ts
@@ -1,4 +1,4 @@
-import { UserInfo, BasicInfoData } from '@/types/apis/userInfo';
+import { BasicInfoData, UserInfo } from '@/types/apis/userInfo';
 
 interface BasicInfoItem {
   label: string;

--- a/src/components/Mypage/Inquiry/InquiryList/inquiryListItem.style.ts
+++ b/src/components/Mypage/Inquiry/InquiryList/inquiryListItem.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const WriteList = styled.div`

--- a/src/components/Mypage/SideNav/Sidenav.tsx
+++ b/src/components/Mypage/SideNav/Sidenav.tsx
@@ -1,7 +1,7 @@
+import React from 'react';
 import LinkButton from '@/components/common/Button/LinkButton';
 import * as I from '@/components/icons/index';
 import * as S from './sidenav.style';
-import React from 'react';
 
 const SideNav = () => {
   const renderNavCategory = () => {

--- a/src/components/Mypage/SideNav/sidenav.style.ts
+++ b/src/components/Mypage/SideNav/sidenav.style.ts
@@ -1,6 +1,7 @@
 'use client';
-import styled from 'styled-components';
+
 import Link from 'next/link';
+import styled from 'styled-components';
 
 export const SideBar = styled.div`
   position: fixed;

--- a/src/components/common/Button/LinkButton/style.ts
+++ b/src/components/common/Button/LinkButton/style.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components';
 import Link from 'next/link';
+import styled from 'styled-components';
 
 export const StyledLink = styled(Link)`
   cursor: pointer;

--- a/src/components/common/CheckBox/checkBox.style.ts
+++ b/src/components/common/CheckBox/checkBox.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const CheckBox = styled.input`

--- a/src/components/common/DropDown/DropDown.tsx
+++ b/src/components/common/DropDown/DropDown.tsx
@@ -1,5 +1,5 @@
+import { ChangeEvent, ReactNode } from 'react';
 import * as S from './dropDown.style';
-import { ReactNode, ChangeEvent } from 'react';
 
 interface DropDownProps {
   label?: string;

--- a/src/components/common/DropDown/dropDown.style.ts
+++ b/src/components/common/DropDown/dropDown.style.ts
@@ -1,4 +1,5 @@
 'use client;';
+
 import styled from 'styled-components';
 
 export const Display = styled.div`

--- a/src/components/common/Footer/Footer.tsx
+++ b/src/components/common/Footer/Footer.tsx
@@ -1,6 +1,6 @@
-import * as S from './footer.style';
 import LinkButton from '@/components/common/Button/LinkButton';
 import * as I from '@/components/icons/index';
+import * as S from './footer.style';
 
 const Footer = () => {
   const securityLinks = () => {

--- a/src/components/common/Footer/footer.style.ts
+++ b/src/components/common/Footer/footer.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const Footer = styled.div`

--- a/src/components/common/Header/Header.tsx
+++ b/src/components/common/Header/Header.tsx
@@ -1,11 +1,11 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
+import Auth from '@/components/Modal/AuthModal/Auth';
 import LinkButton from '@/components/common/Button/LinkButton';
 import * as I from '@/components/icons';
-import { Category } from '@/types/components/header';
-import { ComponentsType } from '@/types';
-import * as S from './header.style';
-import Auth from '@/components/Modal/AuthModal/Auth';
 import useModal from '@/hooks/useModal/usemodal';
+import { ComponentsType } from '@/types';
+import { Category } from '@/types/components/header';
+import * as S from './header.style';
 
 const Header = () => {
   const [isHeaderOpen, setIsHeaderOpen] = useState<boolean>(false);

--- a/src/components/common/Header/header.style.ts
+++ b/src/components/common/Header/header.style.ts
@@ -1,7 +1,7 @@
 'use client';
 
-import styled, { css } from 'styled-components';
 import Link from 'next/link';
+import styled, { css } from 'styled-components';
 
 interface HeaderProps {
   isHeaderOpen: boolean;

--- a/src/components/common/Label/AnswerStatusLabel/answerStatusLabel.style.ts
+++ b/src/components/common/Label/AnswerStatusLabel/answerStatusLabel.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled, { css } from 'styled-components';
 
 interface LabelProps {

--- a/src/components/common/PageTitle/pageTitle.style.ts
+++ b/src/components/common/PageTitle/pageTitle.style.ts
@@ -1,4 +1,5 @@
 'use client;';
+
 import styled from 'styled-components';
 
 export const PageTitle = styled.div`

--- a/src/components/common/Pagination/Pagination.tsx
+++ b/src/components/common/Pagination/Pagination.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { usePathname, useSearchParams } from 'next/navigation';
+
 import { useState } from 'react';
+import { usePathname, useSearchParams } from 'next/navigation';
 import * as I from '@/components/icons/index';
 import * as S from './pagination.style';
 

--- a/src/components/common/Pagination/pagination.style.ts
+++ b/src/components/common/Pagination/pagination.style.ts
@@ -1,5 +1,5 @@
-import styled, { css } from 'styled-components';
 import Link from 'next/link';
+import styled, { css } from 'styled-components';
 
 export const PaginationContainer = styled.nav`
   display: flex;

--- a/src/components/common/SearchBar/SearchBar.tsx
+++ b/src/components/common/SearchBar/SearchBar.tsx
@@ -1,8 +1,9 @@
 'use client';
-import * as S from './searchBar.style';
+
+import React, { useEffect, useState } from 'react';
+import { usePathname, useRouter } from 'next/navigation';
 import * as I from '@/components/icons/index';
-import React, { useState, useEffect } from 'react';
-import { useRouter, usePathname } from 'next/navigation';
+import * as S from './searchBar.style';
 
 const SearchBar = () => {
   const [searchState, setSearchState] = useState<string>('');

--- a/src/components/common/SearchBar/searchBar.style.ts
+++ b/src/components/common/SearchBar/searchBar.style.ts
@@ -1,4 +1,5 @@
 'use client';
+
 import styled from 'styled-components';
 
 export const Container = styled.div`

--- a/src/components/common/ViewCount/ViewCount.tsx
+++ b/src/components/common/ViewCount/ViewCount.tsx
@@ -1,12 +1,13 @@
 'use client';
-import { ReactElement, useEffect, useState, useRef } from 'react';
-import axios from 'axios';
+
+import { ReactElement, useEffect, useRef, useState } from 'react';
 import ArrowUpIcon from '@/components/icons/ArrowUpIcon';
-import ViewCountDropdown from './ViewCountDropdown/ViewCountDropDown';
+import { FormattedViewCountData, ViewCountData } from '@/types/apis/viewCount';
+import { ViewCountCategory } from '@/types/components/viewCount';
 import formatViewData from '@/utils/viewCount/formatViewData';
 import useClickOutside from '@/utils/viewCount/outsideClick';
-import { ViewCountData, FormattedViewCountData } from '@/types/apis/viewCount';
-import { ViewCountCategory } from '@/types/components/viewCount';
+import axios from 'axios';
+import ViewCountDropdown from './ViewCountDropdown/ViewCountDropDown';
 import * as S from './viewCount.style';
 
 const ViewCountButton = (): ReactElement => {

--- a/src/components/icons/index.ts
+++ b/src/components/icons/index.ts
@@ -1,27 +1,27 @@
+import Hamburger from '@/assets/icons/common/Hamburger.svg';
 import Check from '@/assets/icons/common/check.svg';
+import ModalCloseButton from '@/assets/icons/common/modalCloseButton.svg';
 import Facebook from '@/assets/icons/footer/iconFacebook.svg';
-import Twitter from '@/assets/icons/footer/iconTwitter.svg';
 import Instagram from '@/assets/icons/footer/iconInstagram.svg';
 import Naver from '@/assets/icons/footer/iconNaver.svg';
-import History from '@/assets/icons/header/History.svg';
-import Notice from '@/assets/icons/header/noticeboard.svg';
-import Pet from '@/assets/icons/header/Pet.svg';
+import Twitter from '@/assets/icons/footer/iconTwitter.svg';
 import Child from '@/assets/icons/header/Child.svg';
-import Sports from '@/assets/icons/header/Sports.svg';
 import Family from '@/assets/icons/header/Family.svg';
+import History from '@/assets/icons/header/History.svg';
+import Pet from '@/assets/icons/header/Pet.svg';
+import Sports from '@/assets/icons/header/Sports.svg';
 import Academics from '@/assets/icons/header/academics.svg';
 import Ebooks from '@/assets/icons/header/ebooks.svg';
 import Close from '@/assets/icons/header/headerclose.svg';
-import Hamburger from '@/assets/icons/common/Hamburger.svg';
-import SearchIcon from '@/assets/icons/search/icoSearch.svg';
+import HeaderClose from '@/assets/icons/header/headerclose.svg';
+import Notice from '@/assets/icons/header/noticeboard.svg';
 import Mail from '@/assets/icons/inquiry/mail.svg';
-import ModalCloseButton from '@/assets/icons/common/modalCloseButton.svg';
 import Gokey from '@/assets/icons/mypage/goKey.svg';
 import MyInquiry from '@/assets/icons/mypage/myInquiry.svg';
-import ArrowUp from '@/assets/icons/viewCount/arrowUp.svg';
-import HeaderClose from '@/assets/icons/header/headerclose.svg';
 import ArrowLeft from '@/assets/icons/pagination/arrowLeft.svg';
 import ArrowRight from '@/assets/icons/pagination/arrowRight.svg';
+import SearchIcon from '@/assets/icons/search/icoSearch.svg';
+import ArrowUp from '@/assets/icons/viewCount/arrowUp.svg';
 
 export {
   Check,

--- a/src/hooks/useModal/Modal.tsx
+++ b/src/hooks/useModal/Modal.tsx
@@ -1,5 +1,5 @@
-import React, { ReactNode, MouseEvent } from 'react';
-import { ModalWrap, ModalContainer } from './modal.style';
+import React, { MouseEvent, ReactNode } from 'react';
+import { ModalContainer, ModalWrap } from './modal.style';
 
 interface ModalProps {
   onClose: () => void;

--- a/src/styles/registry.tsx
+++ b/src/styles/registry.tsx
@@ -2,6 +2,8 @@
 
 import React, { useState } from 'react';
 import { useServerInsertedHTML } from 'next/navigation';
+import Footer from '@/components/common/Footer/Footer';
+import Header from '@/components/common/Header/Header';
 import {
   ServerStyleSheet,
   StyleSheetManager,
@@ -9,8 +11,6 @@ import {
 } from 'styled-components';
 import { GlobalStyle } from './global';
 import { theme } from './theme';
-import Header from '@/components/common/Header/Header';
-import Footer from '@/components/common/Footer/Footer';
 
 export default function StyledComponentsRegistry({
   children,

--- a/src/utils/viewCount/formatViewData.ts
+++ b/src/utils/viewCount/formatViewData.ts
@@ -1,4 +1,4 @@
-import { ViewCountData, FormattedViewCountData } from '@/types/apis/viewCount';
+import { FormattedViewCountData, ViewCountData } from '@/types/apis/viewCount';
 
 const formatNumber = (value: number): string => {
   if (value >= 1000000) {


### PR DESCRIPTION
# 변경 사항
- prettier-plugin-sort-imports 도입
- 레퍼런스 : (Github : [trivago/prettier-plugin-sort-imports](https://github.com/trivago/prettier-plugin-sort-imports))

# 이후에 수정할 사항
- components 순서 (common -> 나머지 -> 해당 페이지용 컴포넌트) 
- axios

# import 순서 컨밴션

1. react, next, 외부 라이브러리
2. api
3. hooks
4. components (common 먼저, components폴더,  각 페이지의 컴포넌트폴더 순서)  
5. utils
6. interface, type
7. styles
8. 나머지